### PR TITLE
Remove required from "Drop Targets without Data" checkboxes

### DIFF
--- a/app/com/lucidchart/open/nark/views/alerts/create.scala.html
+++ b/app/com/lucidchart/open/nark/views/alerts/create.scala.html
@@ -78,7 +78,7 @@
 					@helper.inputText(formCreate("frequency"), 'class -> "input-xlarge", '_label -> "Frequency in Seconds", 'placeholder -> "0", 'required -> true, '_showConstraints -> false)
 					@helper.inputText(formCreate("data_seconds"), 'class -> "input-xlarge", '_label -> "Data to Query in Seconds", 'placeholder -> "60", 'required -> true, '_showConstraints -> false)
 					@helper.inputText(formCreate("drop_null_points"), 'class -> "input-xlarge", '_label -> "Null Data Points to Drop", 'placeholder -> "60", 'required -> true, '_showConstraints -> false)
-					@helper.checkbox(formCreate("drop_null_targets"), 'class -> "input-xlarge", '_label -> "Drop Targets without Data", 'required -> true, '_showConstraints -> false)
+					@helper.checkbox(formCreate("drop_null_targets"), 'class -> "input-xlarge", '_label -> "Drop Targets without Data", '_showConstraints -> false)
 					<br />
 					<br />
 					<button id="create" name="create" class="btn btn-primary">Create</button>

--- a/app/com/lucidchart/open/nark/views/dynamicalerts/create.scala.html
+++ b/app/com/lucidchart/open/nark/views/dynamicalerts/create.scala.html
@@ -80,7 +80,7 @@
 					@helper.inputText(formCreate("frequency"), 'class -> "input-xlarge", '_label -> "Frequency in Seconds", 'placeholder -> "0", 'required -> true, '_showConstraints -> false)
 					@helper.inputText(formCreate("data_seconds"), 'class -> "input-xlarge", '_label -> "Data to Query in Seconds", 'placeholder -> "60", 'required -> true, '_showConstraints -> false)
 					@helper.inputText(formCreate("drop_null_points"), 'class -> "input-xlarge", '_label -> "Null Data Points to Drop", 'placeholder -> "60", 'required -> true, '_showConstraints -> false)
-					@helper.checkbox(formCreate("drop_null_targets"), 'class -> "input-xlarge", '_label -> "Drop Targets without Data", 'required -> true, '_showConstraints -> false)
+					@helper.checkbox(formCreate("drop_null_targets"), 'class -> "input-xlarge", '_label -> "Drop Targets without Data", '_showConstraints -> false)
 					<br />
 					<br />
 					<button id="create" name="create" class="btn btn-primary">Create</button>

--- a/app/com/lucidchart/open/nark/views/dynamicalerts/edit.scala.html
+++ b/app/com/lucidchart/open/nark/views/dynamicalerts/edit.scala.html
@@ -89,7 +89,7 @@
 					@helper.inputText(formEdit("frequency"), 'class -> "input-xlarge", '_label -> "Frequency in Seconds", 'placeholder -> "0", 'required -> true, '_showConstraints -> false)
 					@helper.inputText(formEdit("data_seconds"), 'class -> "input-xlarge", '_label -> "Data to Query in Seconds", 'placeholder -> "60", 'required -> true, '_showConstraints -> false)
 					@helper.inputText(formEdit("drop_null_points"), 'class -> "input-xlarge", '_label -> "Null Data Points to Drop", 'placeholder -> "60", 'required -> true, '_showConstraints -> false)
-					@helper.checkbox(formEdit("drop_null_targets"), 'class -> "input-xlarge", '_label -> "Drop Targets without Data", 'required -> true, '_showConstraints -> false)
+					@helper.checkbox(formEdit("drop_null_targets"), 'class -> "input-xlarge", '_label -> "Drop Targets without Data", '_showConstraints -> false)
 					@helper.checkbox(formEdit("active"), 'class -> "input-xlarge", '_label -> "Active", 'placeholder -> true, '_text -> "", '_help -> "")
 					<br />
 				</fieldset>


### PR DESCRIPTION
Otherwise, Javascript will not allow submission when the checkbox is unchecked.

(Because of this a required checkbox only makes sense for things like "Accept terms", etc.)
